### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/django.js
+++ b/django.js
@@ -14,7 +14,11 @@ function Django(nWorker, image, mongo, env = {}) {
 
   this.containers = [];
   for (let i = 0; i < nWorker; i += 1) {
-    this.containers.push(new Container('django-poll', image).withEnv(envWithMongo));
+    this.containers.push(new Container({
+      name: 'django-poll',
+      image,
+      env: envWithMongo,
+    }));
   }
   mongo.allowTrafficFrom(this.containers, mongo.port);
 }

--- a/djangoExample.js
+++ b/djangoExample.js
@@ -9,9 +9,10 @@ const numReplicas = 3;
 const baseMachine = new Machine({ provider: 'Amazon' });
 
 // Create infrastructure.
-const infra = new Infrastructure(
-  baseMachine,
-  baseMachine.replicate(numReplicas));
+const infra = new Infrastructure({
+  masters: baseMachine,
+  workers: baseMachine.replicate(numReplicas),
+});
 
 // Create applications.
 const mongo = new Mongo(numReplicas);


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.